### PR TITLE
Remove Anomaly Crate from the telepad loot pool

### DIFF
--- a/Resources/Prototypes/2G2C/Entities/Structures/cargo_console.yml
+++ b/Resources/Prototypes/2G2C/Entities/Structures/cargo_console.yml
@@ -41,7 +41,6 @@
         - InterceptedCrateMedical
         - InterceptedCrateWeaponry
         - InterceptedCrateWeaponry
-        - InterceptedCrateAnomaly
       chance: 1
       intervalSeconds: 300
       minimumEntitiesSpawned: 1


### PR DESCRIPTION
The game is no longer Colonial Marines. Thank god.